### PR TITLE
Add systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Dependencies
   * Ubuntu: apt-get install python-dnspython
 * (optional) python gevent library. Only needed if you execute the
   script directly to run a standalone web server.
+  * Homepage: http://www.gevent.org/
+  * Ubuntu: apt-get install python-gevent
 * (optional) gunicorn. Only needed if you want to use the included
   check-xmpp-dns.conf upstart config to run the script as a system service.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dependencies
 * (optional) python gevent library. Only needed if you execute the
   script directly to run a standalone web server.
 * (optional) gunicorn. Only needed if you want to use the included
-  check-xmpp-dns.conf upstart config to runt he script as a system service.
+  check-xmpp-dns.conf upstart config to run the script as a system service.
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ Dependencies
   script directly to run a standalone web server.
   * Homepage: http://www.gevent.org/
   * Ubuntu: apt-get install python-gevent
-* (optional) gunicorn. Only needed if you want to use the included
-  check-xmpp-dns.conf upstart config to run the script as a system service.
-
+* (optional) gunicorn. Only needed if you want to use the included upstart or systemd service
+  * install: apt-get install gunicorn
+  * upstart: check-xmpp-dns.conf upstart config to run the script as a system service.
+  * systemd: (be sure paths, user and permissions are set properly). 
+  copy check_xmpp_dns.service to /etc/systemd/system/check_xmpp_dns.service
+  copy tmpfiles.d_gunicorn.conf to /etc/tmpfiles.d/gunicorn.conf 
 
 Usage
 =====
 This script's main method starts a standard HTTP server on port 1000 using
 the gevent WSGI server. You may wish to proxy traffic to this port from
 another web server. You can use the included check-xmpp-dns.conf upstart
-config file to run the script as a system service.
+config file or systemd service to run the script as a system service.
 
 Or you can use any other WSGI server to start the script's 'application'
 method.

--- a/check_xmpp_dns.service
+++ b/check_xmpp_dns.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Python WSGI check_xmpp_dns
+After=syslog.target network.target
+
+[Service]
+User=check-xmpp-dns
+Group=check-xmpp-dns
+RuntimeDirectory=gunicorn
+WorkingDirectory=/srv/check_xmpp_dns
+PIDFile=/var/run/gunicorn/check_xmpp_dns.pid
+ExecStart=/usr/bin/gunicorn check_xmpp_dns:application --log-file=log --bind unix:/tmp/check_xmpp_dns.socket --workers=5 --pid=/var/run/gunicorn/check_xmpp_dns.pid
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target
+

--- a/tmpfiles.d_gunicorn.conf
+++ b/tmpfiles.d_gunicorn.conf
@@ -1,0 +1,2 @@
+d /var/run/gunicorn 0755 check-xmpp-dns check-xmpp-dns -
+


### PR DESCRIPTION
I complete the readme and add some files and information to create a systemd service. Actually the readme steps are not a "how to", they need a proper set up. I just migrated upstart configuration variables to systemd.

My systemd configuration is
```
[Unit]
Description=Python WSGI check_xmpp_dns
After=syslog.target network.target

[Service]
User=www-data
Group=www-data
RuntimeDirectory=gunicorn
WorkingDirectory=/srv/check_xmpp_dns
PIDFile=/var/run/gunicorn/check_xmpp_dns.pid
ExecStart=/usr/bin/gunicorn check_xmpp_dns:application --log-file=/var/log/check_xmpp_dns.log --bind 0.0.0.0:8999 --workers=5 --pid=/var/run/gunicorn/check_xmpp_dns.pid
ExecReload=/bin/kill -s HUP $MAINPID
ExecStop=/bin/kill -s TERM $MAINPID
PrivateTmp=true

[Install]
WantedBy=default.target

```