### PR TITLE
Add xep-0368 client checks

### DIFF
--- a/check_xmpp_dns.py
+++ b/check_xmpp_dns.py
@@ -268,7 +268,10 @@ class RequestHandler:
             # TODO: Show "invalid hostname" for this
             client_records = []
         except dns.resolver.NXDOMAIN:
-            client_records = []
+            client_records = dns_resolver.query(
+                '_xmpps-client._tcp.%s' % hostname, rdtype=dns.rdatatype.SRV)
+            if dns.resolver.NXDOMAIN
+              client_records = []
         except dns.resolver.NoAnswer:
             # TODO: Show a specific message for this
             client_records = []
@@ -289,7 +292,10 @@ class RequestHandler:
             # TODO: Show "invalid hostname" for this
             server_records = []
         except dns.resolver.NXDOMAIN:
-            server_records = []
+            server_records = dns_resolver.query(
+                '_xmpps-server._tcp.%s' % hostname, rdtype=dns.rdatatype.SRV)
+            if dns.resolver.NXDOMAIN
+              server_records = []
         except dns.resolver.NoAnswer:
             # TODO: Show a specific message for this
             server_records = []


### PR DESCRIPTION
In [XEP-0368: SRV records for XMPP over TLS](https://xmpp.org/extensions/xep-0368.html) is written the following.

```
Both 'xmpp-' and 'xmpps-' records SHOULD be treated as the same record with regard to connection order as specified by RFC 2782 [3], in that all priorities and weights are mixed. This enables the server operator to decide if they would rather clients connect with STARTTLS or direct TLS. However, clients MAY choose to prefer one type of connection over the other.
```

This PR adds the check for the `xmpps-` after a failed `xmpp-`